### PR TITLE
Fixed Install.rs file path not found error

### DIFF
--- a/src/bin/install.rs
+++ b/src/bin/install.rs
@@ -105,7 +105,7 @@ fn windows() -> Result<(), Box<dyn std::error::Error>> {
             // remove old folder called 'orbit'
             std::fs::remove_dir_all(dest)?;
             // rename original folder name to 'orbit'
-            std::fs::rename(contents.file_name().unwrap(), "orbit")?;
+            std::fs::rename(path.join(contents.file_name().unwrap()).unwrap(), path.join("orbit").unwrap())?;
             println!("successfully installed orbit");
             println!("{} add {} to the user PATH variable to call `orbit` from the command-line", "tip:".blue().bold(), path.join("orbit/bin").display());
         }


### PR DESCRIPTION
Added the full explicit file path to the folder location rather than just the name. Executable isn't running in the directory where the folder ended up, so the relative reference wasn't really valid.