### PR TITLE
Use the current branch for CI pipeline definitions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,33 +6,33 @@ on:
 
 jobs:
   tools:
-    uses: chaseruskin/orbit/.github/workflows/tools.yml@trunk
-    
+    uses: ./.github/workflows/tools.yml
+
   check-release:
-    uses: chaseruskin/orbit/.github/workflows/check-release.yml@trunk
+    uses: ./.github/workflows/check-release.yml
     needs: [tools]
 
   test:
-    uses: chaseruskin/orbit/.github/workflows/test.yml@trunk
+    uses: ./.github/workflows/test.yml
 
   build:
-    uses: chaseruskin/orbit/.github/workflows/build.yml@trunk
+    uses: ./.github/workflows/build.yml
     needs: [tools, check-release, test]
     with:
       is_release: ${{ needs.check-release.outputs.ready }}
 
   integrity:
-    uses: chaseruskin/orbit/.github/workflows/integrity.yml@trunk
+    uses: ./.github/workflows/integrity.yml
     needs: [tools, build]
 
   system-test:
-    uses: chaseruskin/orbit/.github/workflows/system-test.yml@trunk
+    uses: ./.github/workflows/system-test.yml
     needs: [check-release, integrity]
     with:
       version: ${{ needs.check-release.outputs.version }}
 
   docker-build:
-    uses: chaseruskin/orbit/.github/workflows/docker.yml@trunk
+    uses: ./.github/workflows/docker.yml
     needs: [check-release, system-test]
     if: ${{ github.ref == 'refs/heads/trunk' }}
     secrets:
@@ -43,7 +43,7 @@ jobs:
       is_release: ${{ needs.check-release.outputs.ready }}
 
   release:
-    uses: chaseruskin/orbit/.github/workflows/release.yml@trunk
+    uses: ./.github/workflows/release.yml
     if: ${{ needs.check-release.outputs.ready == '1' && github.ref == 'refs/heads/trunk' }}
     needs: [check-release, system-test, docker-build]
     with:


### PR DESCRIPTION
This will support atomic updates where CI changes in accordance with the current pull-request 