### PR TITLE
Add source archives to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,15 @@ jobs:
         pattern: orbit-${{ inputs.version }}-*
         merge-multiple: true
 
+    - name: Create source archive
+      run: |
+        git archive \
+          --format=tar.gz \
+          --prefix=orbit-${{ inputs.version }}/ \
+          -o ./orbit-${{ inputs.version }}-source.tar.gz \
+          HEAD
+        python ./tools/sum.py "./orbit-${{ inputs.version }}-source.tar.gz" >> ./SHA256SUMS
+
     - name: Display filesystem contents
       run: ls -R
 


### PR DESCRIPTION
Source artifacts in releases are the a stable means of accessing a snapshot of the code that's byte-for-byte consistent. Some details can be found here: https://github.com/orgs/community/discussions/46034